### PR TITLE
Fix canUseDOM for SSR

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -81,8 +81,8 @@
     "gzipped": 9217
   },
   "dist/rbx.umd.js": {
-    "bundled": 89389,
-    "minified": 45120,
-    "gzipped": 9269
+    "bundled": 89398,
+    "minified": 45131,
+    "gzipped": 9273
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1215,20 +1215,28 @@
       }
     },
     "@mdx-js/loader": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@mdx-js/loader/-/loader-0.16.6.tgz",
-      "integrity": "sha512-DwQzr1pzzB7NifXHbotXO6fQzzKAhM3oI8qY35k8AafiZay12UiUULOLCg4keau7SO+fKd6OjXSrc1N+wU6J+Q==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@mdx-js/loader/-/loader-0.16.8.tgz",
+      "integrity": "sha512-uTwUY2IO/r0Bsp166WwKYCpkGkTKQJx9Cvq8PROGEeGIejcrNcqic0egv+dreHTzP1V9kS6JQJkurnbUx+IhtQ==",
       "dev": true,
       "requires": {
-        "@mdx-js/mdx": "^0.16.6",
-        "@mdx-js/tag": "^0.16.6",
+        "@mdx-js/mdx": "^0.16.8",
+        "@mdx-js/tag": "^0.16.8",
         "loader-utils": "^1.1.0"
+      },
+      "dependencies": {
+        "@mdx-js/tag": {
+          "version": "0.16.8",
+          "resolved": "https://registry.npmjs.org/@mdx-js/tag/-/tag-0.16.8.tgz",
+          "integrity": "sha512-19dIHmmCHyZpKxsOxAPNB1itG9DKnnSYOsnibYQbyl5YXxZTDMyGD7tZitGm7y7vQpcLhQxmAHykM3l7yeKCDg==",
+          "dev": true
+        }
       }
     },
     "@mdx-js/mdx": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-0.16.6.tgz",
-      "integrity": "sha512-OJDun9/lt8c5tIWVNwjgFIkHtSWR3HOS+CmM5nW3BJKY5i4RSeVLekWkcCMpzujZtBF1frbjTM4bF9fD6LN8mQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-0.16.8.tgz",
+      "integrity": "sha512-HqipqjFh0/Fag+a3KO0IBbUjZUPtSOW2dBDOSMlYswnRLrqy6pOATAqwk3wXJku4jUe2zX5GVtuFV60BBHmjnA==",
       "dev": true,
       "requires": {
         "change-case": "^3.0.2",
@@ -1243,9 +1251,9 @@
       }
     },
     "@mdx-js/mdxast": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@mdx-js/mdxast/-/mdxast-0.16.6.tgz",
-      "integrity": "sha512-8LEd4FOZrlbClYUpXZGrwyENOM0Npjfgrykl0r7bvtIjigJGOwQLdxK6sRy2AcKTBDnMMdmZ5e7htHG+0GYLng==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@mdx-js/mdxast/-/mdxast-0.16.8.tgz",
+      "integrity": "sha512-PcTGLgPIywggyTA7NwQIKTP8lH1Nxfz4IBhuhpO+66OVpfib1M3oAscYrvoWh0eSiuIpvNqmXYsnTWIWgZl2sA==",
       "dev": true,
       "requires": {
         "unist-util-visit": "^1.3.0"
@@ -12309,9 +12317,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.0.tgz",
-      "integrity": "sha512-MCBCYeAuZfejUPdEpkleLWvpRBwLii/Sp5jQs0eb8Ul/drGIDjkL6tAU24tk6yCGf0KPV5rhPPPlczfBmN2pWQ==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.1.tgz",
+      "integrity": "sha512-XXUITwIkGb3CPJ2hforHah/zTINRyie5006Jd2HKy2qz7snEJXl0KLfsJZW/wst9g6R2rFvqba3VpNYdu1hDcA==",
       "dev": true
     },
     "pretty-format": {
@@ -16701,9 +16709,9 @@
       }
     },
     "webpack-chain": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/webpack-chain/-/webpack-chain-5.1.0.tgz",
-      "integrity": "sha512-FWMw3zyXOdSkU+VYCtRid7i9PJ4H7Zp8NnBM3U+7DBDcPw4WQ7KGkBlRerfcZ3zk8qX77RoU0w57LGU1OFFMlg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/webpack-chain/-/webpack-chain-5.2.0.tgz",
+      "integrity": "sha512-JXz9YgEkTqx8hvnES2VMRyWHNFlqJfLmA5QTyuJOXalkGg+MVdOgB0UaYtc4iDadEmzJLe8UyCl4wyDq3wWZDg==",
       "dev": true,
       "requires": {
         "deepmerge": "^1.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rbx",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "The Comprehensive Bulma UI Framework for React",
   "main": "dist/rbx.umd.js",
   "module": "dist/index.js",

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -14,8 +14,19 @@ describe("Utils", () => {
       expect(canUseDOM()).toBe(true);
     });
 
-    it("should return false without window", () => {
+    it("should return false when window is not defined (SSR)", () => {
+      // tslint:disable-next-line:no-any
+      delete (global as any).window;
+
+      expect(() => {
+        window; // tslint:disable-line:no-unused-expression
+      }).toThrow(new ReferenceError("window is not defined"));
+      expect(canUseDOM()).toBe(false);
+    });
+
+    it("should return false when window is undefined", () => {
       withWindow({}, () => {
+        expect(window).toBeUndefined();
         expect(canUseDOM()).toBe(false);
       });
     });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,7 @@ import { Lit } from "./types";
 
 export const canUseDOM = () =>
   !(
-    window === undefined ||
+    typeof window === "undefined" || // tslint:disable-line:no-typeof-undefined
     window.document === undefined ||
     window.document.createElement === undefined
   );


### PR DESCRIPTION
- Node environment does not have `window` so `window ==== undefined` will
throw a reference error. This causes issues in SSR (e.g. Gatsby/Next)
- Fixes #5 