### PR TITLE
fix missing backtick typo

### DIFF
--- a/src/components/navbar/__docs__/navbar.docs.mdx
+++ b/src/components/navbar/__docs__/navbar.docs.mdx
@@ -476,7 +476,7 @@ To create a **\*dropdown menu** you'll need the following **5** components:
 
 - `<Navbar.Item>` with the `dropdown` prop
 - `<Navbar.Link>` which contains the dropdown arrow
-- `<Navbar.Dropdown>` which contains instances of `<Navbar.Item> and`<Navbar.Divider>`
+- `<Navbar.Dropdown>` which contains instances of `<Navbar.Item>` and`<Navbar.Divider>`
 
 <Playground>
   <div style={{ height: "200px " }}>


### PR DESCRIPTION
... but there are still errors - now `docz dev` is complaining

```
./node_modules/docz-theme-default/node_modules/docz/dist/index.m.js
Module not found: Can't resolve '~db' in '/Users/100ideas/dev/da-play/0_mock/rbx/node_modules/docz-theme-default/node_modules/docz/dist'
```
so upgraded `docz-theme-default` to  `latest` (v1.0.4), deleted `./docz/` cache, and ran `$ ./node_modules/.bin/docz dev`... and got react errors in browser when looking at rbx components in docz:

```
(BaseSimplePropsTable, in code (at simple-props-table.tsx:131)) Invariant Violation: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: undefined. You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports. Check the render method of `BaseSimplePropsTable`.
```

but the components do render and can be clicked. there's just a big error box. 😢 

also, there is a mismatch between how the make tasks are named in the Makefile and how they are called from npm package.json scripts. Makefile uses hyphen like 'docs-dev' but package.json uses underscore like 'docs_dev'. Also, in package.json, should build command be 'make' or 'make build'? latter doesn't work for me.