### PR TITLE
In section.docs.mdx use <Section> in first example

### DIFF
--- a/src/layout/section/__docs__/section.docs.mdx
+++ b/src/layout/section/__docs__/section.docs.mdx
@@ -20,13 +20,13 @@ import { Section, SECTION_DEFAULTS } from "../section";
 A simple container to divide your page into **sections**.
 
 <Playground>
-  <Container>
+  <Section>
     <Title>Section</Title>
     <Title as="h2" subtitle>
       A simple container to divide your page into <strong>sections</strong>,
       like the one you are currently reading
     </Title>
-  </Container>
+  </Section>
 </Playground>
 
 ### Sizing


### PR DESCRIPTION
Previously, the first example used `<Container>`. Other examples were already on `<Section>`.