### PR TITLE
tooltip API doc: fix tooltipMultiline name

### DIFF
--- a/src/base/__docs__/tooltip.docs.mdx
+++ b/src/base/__docs__/tooltip.docs.mdx
@@ -135,8 +135,8 @@ The `tooltip` API is built into the `<Generic>` component, so these props can be
       typeName: "string (literal)",
       typeTip: mapEnumerable(DEFAULTS.colors),
     },
-    tooltipActive: {
-      description: "allow the tooltip text to flow over multipe lines",
+    tooltipMultiline: {
+      description: "allow the tooltip text to flow over multiple lines",
       typeName: "boolean",
     },
     tooltipPosition: {


### PR DESCRIPTION
Previously said tooltipActive.

Also fixes a very minor typo. 'multipe' to 'multiple'