### PR TITLE
fix Navbar.Item active props bug

### DIFF
--- a/src/components/navbar/navbar-item-container.tsx
+++ b/src/components/navbar/navbar-item-container.tsx
@@ -73,7 +73,6 @@ export class NavbarItemContainer extends React.PureComponent<
       {
         "has-dropdown": dropdown,
         "has-dropdown-up": up,
-        "is-active": this.active,
         "is-expanded": expanded,
         "is-hoverable": hoverable,
         "is-tab": tab,
@@ -93,7 +92,12 @@ export class NavbarItemContainer extends React.PureComponent<
             setActive: (value: boolean) => (this.active = value),
           }}
         >
-          <Generic as={asOverride} className={className} ref={ref} {...rest} />
+          <Generic
+            as={asOverride}
+            className={classNames(className, { "is-active": this.active })}
+            ref={ref}
+            {...rest}
+          />
         </NavbarItemContext.Provider>
       );
     }
@@ -103,7 +107,9 @@ export class NavbarItemContainer extends React.PureComponent<
         {ctx => (
           <Generic
             as={as}
-            className={className}
+            className={classNames(className, {
+              "is-active": this.props.active,
+            })}
             onClick={this.handleOnClick(ctx)}
             ref={ref}
             {...rest}


### PR DESCRIPTION
Currently, when clicking a Navbar.Item with active prop triggering a re-render of the component, the prop active will be ignored, which leads to the `is-active` class never changing. It's working as intended in Dropdown.Item however.

[Here's an example](https://codesandbox.io/s/condescending-lamport-e0zwf) - regardless of the item clicked, the first item will have 'is-active'.

